### PR TITLE
Feature/config tool compatiblity

### DIFF
--- a/helpers/mapSettings.js
+++ b/helpers/mapSettings.js
@@ -1,6 +1,28 @@
 const postgres = require("./postgres");
 
 module.exports = {
+  getAllMaps: function (callback) {
+    var sql = `SELECT map_name,description,allowed_roles,is_secured,is_default FROM public.usp_get_all_maps($1)`;
+    var values = [false];
+    const pg = new postgres({ dbName: "tabular" });
+    pg.selectAllWithValues(sql, values, (result) => {
+      // Check if result is an error object
+      if (result && result.error) {
+        console.error("Error in getAllMaps:", result.error);
+        callback(result);
+        return;
+      }
+
+      // Check if result is empty array
+      if (!result || result.length === 0) {
+        console.warn("getAllMaps returned no records");
+        callback([]);
+        return;
+      }
+
+      callback(result);
+    });
+  },
   getMap: function (id, callback) {
     var sql = `SELECT json FROM public.usp_get_map_settings($1,$2,$3)`;
     var values = [id, null, false];

--- a/helpers/mapSettings.js
+++ b/helpers/mapSettings.js
@@ -2,18 +2,32 @@ const postgres = require("./postgres");
 
 module.exports = {
   getMap: function (id, callback) {
-    var sql = `select json from public.tbl_map_settings where is_secured = false and id = $1`;
-    var values = [id];
+    var sql = `SELECT json FROM public.usp_get_map_settings($1,$2,$3)`;
+    var values = [id, null, false];
+    const pg = new postgres({ dbName: "tabular" });
+    pg.selectFirstWithValues(sql, values, (result) => {
+      callback(result);
+    });
+  },
+  getMapVersion: function (id, version, callback) {
+    var sql = `SELECT json, published FROM public.usp_get_map_settings($1,$2,$3)`;
+    var values = [id, version, false];
     const pg = new postgres({ dbName: "tabular" });
     pg.selectFirstWithValues(sql, values, (result) => {
       callback(result);
     });
   },
   getDefaultMap: function (callback) {
-    var sql = `select json from public.tbl_map_settings where is_secured = false and is_default = true`;
+    var sql = `SELECT json FROM public.usp_get_map_settings($1,$2,$3)`;
+    var values = [null, null, false];
+
     const pg = new postgres({ dbName: "tabular" });
-    pg.selectFirst(sql, (result) => {
-      callback(result);
-    });
+    try {
+      pg.selectFirstWithValues(sql, values, (result) => {
+        callback(result);
+      });
+    } catch (e) {
+      console.log(e);
+    }
   },
 };

--- a/routes/public/map/index.js
+++ b/routes/public/map/index.js
@@ -32,6 +32,43 @@ module.exports = (baseRoute, middleWare, router) => {
       return next();
     }
   });
+  router.get(baseRoute + "/:id/:version", middleWare, (req, res, next) => {
+    /* 
+      #swagger.tags = ['Public/Map']
+      #swagger.path = '/public/map/{id}/{version}'
+      #swagger.deprecated = false
+      #swagger.ignore = false
+      #swagger.summary = 'Retrieve Map config version'
+       #swagger.parameters['id'] = {
+          in: 'path',
+          description: 'Map ID',
+          required: true,
+          type: 'string'
+      } 
+          #swagger.parameters['version'] = {
+          in: 'path',
+          description: 'Version',
+          required: true,
+          type: 'string'
+      } 
+    */
+    try {
+      if (!common.isHostAllowed(req, res)) return;
+      mapSettings.getMapVersion(req.params.id, req.params.version, (result) => {
+        if (result === undefined) {
+          res.json({ error: "ID Not Found" });
+        } else {
+          res.json(result);
+        }
+        return next();
+      });
+    } catch (e) {
+      console.error(e.stack);
+      res.status(500);
+      res.send();
+      return next();
+    }
+  });
   router.get(baseRoute + "/default", middleWare, (req, res, next) => {
     /* 
       #swagger.tags = ['Public/Map']

--- a/routes/public/map/index.js
+++ b/routes/public/map/index.js
@@ -7,13 +7,25 @@ module.exports = (baseRoute, middleWare, router) => {
       #swagger.path = '/public/map/{id}'
       #swagger.deprecated = false
       #swagger.ignore = false
-      #swagger.summary = 'Retrieve Map config'
-       #swagger.parameters['id'] = {
+      #swagger.summary = 'Retrieve the latest configuration for a specific map'
+      #swagger.description = 'Fetches the most recent configuration settings for a map identified by its unique ID. Returns the map configuration in JSON format.'
+      #swagger.parameters['id'] = {
           in: 'path',
-          description: 'Map ID',
+          description: 'Unique identifier of the map',
           required: true,
           type: 'string'
       } 
+      #swagger.responses[200] = {
+          description: 'Successful operation. Returns the map configuration.',
+          schema: { $ref: '#/definitions/MapConfig' }
+      }
+      #swagger.responses[404] = {
+          description: 'Map not found',
+          schema: { error: 'ID Not Found' }
+      }
+      #swagger.responses[500] = {
+          description: 'Internal server error'
+      }
     */
     try {
       if (!common.isHostAllowed(req, res)) return;
@@ -38,19 +50,31 @@ module.exports = (baseRoute, middleWare, router) => {
       #swagger.path = '/public/map/{id}/{version}'
       #swagger.deprecated = false
       #swagger.ignore = false
-      #swagger.summary = 'Retrieve Map config version'
-       #swagger.parameters['id'] = {
+      #swagger.summary = 'Retrieve a specific version of a map configuration'
+      #swagger.description = 'Fetches a particular version of configuration settings for a map identified by its unique ID and version number. Useful for accessing historical configurations.'
+      #swagger.parameters['id'] = {
           in: 'path',
-          description: 'Map ID',
+          description: 'Unique identifier of the map',
           required: true,
           type: 'string'
       } 
-          #swagger.parameters['version'] = {
+      #swagger.parameters['version'] = {
           in: 'path',
-          description: 'Version',
+          description: 'Version number of the map configuration',
           required: true,
           type: 'string'
       } 
+      #swagger.responses[200] = {
+          description: 'Successful operation. Returns the specified version of map configuration.',
+          schema: { $ref: '#/definitions/MapConfig' }
+      }
+      #swagger.responses[404] = {
+          description: 'Map or version not found',
+          schema: { error: 'ID Not Found' }
+      }
+      #swagger.responses[500] = {
+          description: 'Internal server error'
+      }
     */
     try {
       if (!common.isHostAllowed(req, res)) return;
@@ -75,8 +99,19 @@ module.exports = (baseRoute, middleWare, router) => {
       #swagger.path = '/public/map/default'
       #swagger.deprecated = false
       #swagger.ignore = false
-      #swagger.summary = 'Retrieve Default Map config'
-      
+      #swagger.summary = 'Retrieve the default map configuration'
+      #swagger.description = 'Fetches the system-wide default map configuration. This configuration serves as a template or fallback when specific map configurations are not available.'
+      #swagger.responses[200] = {
+          description: 'Successful operation. Returns the default map configuration.',
+          schema: { $ref: '#/definitions/MapConfig' }
+      }
+      #swagger.responses[404] = {
+          description: 'Default configuration not found',
+          schema: { error: 'ID Not Found' }
+      }
+      #swagger.responses[500] = {
+          description: 'Internal server error'
+      }
     */
     try {
       if (!common.isHostAllowed(req, res)) return;


### PR DESCRIPTION
This pull request introduces enhancements to the map settings functionality, improves error handling in the PostgreSQL helper, and adds new API endpoints for retrieving map configurations. The most important changes include adding new methods for map retrieval, improving error logging in the database helper, and extending the public API for map-related operations.

### Enhancements to Map Settings (`helpers/mapSettings.js`):
* Added `getAllMaps` and `getMapVersion` methods to retrieve all map configurations and specific versions of a map, respectively. These methods leverage new stored procedures for enhanced functionality.

### Improvements to PostgreSQL Helper (`helpers/postgres.js`):
* Introduced `_logError` method for detailed error logging, including SQL queries, parameters, and stack traces. This improves debugging and monitoring.
* Enhanced error handling across database query methods (`selectFirst`, `selectAll`, `selectAllWithValues`, etc.) to log errors and return meaningful error messages. [[1]](diffhunk://#diff-b1ad1a843b75ed17921b77f6c8291f79759f013a3b6372382891b33af6bd470bL51-R98) [[2]](diffhunk://#diff-b1ad1a843b75ed17921b77f6c8291f79759f013a3b6372382891b33af6bd470bL64-R117) [[3]](diffhunk://#diff-b1ad1a843b75ed17921b77f6c8291f79759f013a3b6372382891b33af6bd470bL76-R135)
* Updated `selectAllWithValuesWait` to include proper error logging and removed commented-out code for better readability.

### Additions to Public API (`routes/public/map/index.js`):
* Added a new endpoint `/public/map/all` to retrieve all available map configurations, including metadata like name, description, and security settings.
* Introduced a new endpoint `/public/map/{id}/{version}` to fetch a specific version of a map configuration, enabling access to historical configurations.
* Enhanced Swagger documentation for existing endpoints to provide more detailed descriptions, parameters, and response schemas. [[1]](diffhunk://#diff-f57e21287e9e55c903583547e1bfb9da580bd3e5238b4f205320a1bd69d43a3cR4-R88) [[2]](diffhunk://#diff-f57e21287e9e55c903583547e1bfb9da580bd3e5238b4f205320a1bd69d43a3cR107-R174)