### PR TITLE
511 waze update

### DIFF
--- a/helpers/mto.js
+++ b/helpers/mto.js
@@ -1,175 +1,173 @@
-// IMPORTS
-var polyline = require("@mapbox/polyline");
-var GeoJSON = require("geojson");
+/**
+ * MTO (Ministry of Transportation Ontario) 511 Service
+ * Fetches traffic data from 511on.ca API and converts to GeoJSON
+ */
+
+const polyline = require("@mapbox/polyline");
+const GeoJSON = require("geojson");
 const fetch = require("./fetchWrapper");
 
-var moment = require("moment");
-
 // GET CONFIG
-var mtoSites = require("./mto_config.json");
+const mtoSites = require("./mto_config.json");
 
-module.exports = {
-  // MAIN FUNCTION
-  getMTOLayer: function (layerName, callback) {
-    // GET LAYER DETAILS FROM CONFIG
-    var layerDetails = mtoSites.sites[layerName];
-    if (layerDetails == undefined) return null;
+// Road condition areas from config
+const roadConditionAreas = mtoSites.sites["roadConditionAreas"];
 
-    if (layerDetails.geoType == "POINT") {
-      // GET POINT LAYER
-      getMTOPointLayer(layerDetails.url, function (response) {
-        callback(response);
-      });
-    } else if (layerDetails.geoType == "POLYLINE") {
-      // GET POLYLINE LAYER
-      getMTOPolylineLayer(layerDetails.url, mtoSites.sites["roadConditionAreas"], function (response) {
-        callback(response);
-      });
-    } else {
-      //GET ALERTS (NO GEOMETRY)
-      getMTOAlerts(layerDetails.url, function (response) {
-        callback(response);
-      });
+/**
+ * Check if coordinates are within Simcoe County bounds
+ */
+function isInCounty(long, lat) {
+  return long > -80.5 && long < -79 && lat > 43.9 && lat < 45;
+}
+
+/**
+ * Format Unix timestamp to readable date string
+ */
+function formatDate(timestamp) {
+  const date = new Date(timestamp * 1000);
+  return date.toLocaleString("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  });
+}
+
+/**
+ * Fetch MTO alerts (no geometry)
+ */
+async function getMTOAlerts(url) {
+  const response = await fetch(url);
+  return response.json();
+}
+
+/**
+ * Fetch MTO polyline layer data (road conditions, HOV lanes)
+ */
+async function getMTOPolylineLayer(url) {
+  const response = await fetch(url);
+  const allMTO = await response.json();
+  const allMTOWithGeoJSON = [];
+
+  for (const element of allMTO) {
+    // Only return roads with snow or ice conditions
+    const mainCondition = element.Condition[0]?.toUpperCase() || "";
+
+    if (mainCondition.includes("SNOW") || mainCondition.includes("ICE")) {
+      // Decode polyline to GeoJSON
+      const geoJSONGeom = polyline.toGeoJSON(element.EncodedPolyline);
+      element.geoJSON = geoJSONGeom;
+
+      // Delete the encoded polyline
+      delete element.EncodedPolyline;
+
+      // Set to English only (split bilingual description)
+      if (element.LocationDescription !== undefined) {
+        const englishDescription = element.LocationDescription.split("|")[0];
+        element.LocationDescription = englishDescription;
+
+        // Only use the roads found in config
+        if (roadConditionAreas.includes(englishDescription)) {
+          allMTOWithGeoJSON.push(element);
+        }
+      } else {
+        allMTOWithGeoJSON.push(element);
+      }
     }
-  },
-};
+  }
 
-//ALERTS
-function getMTOAlerts(url, callback) {
-  fetch(url)
-    .then((res) => res.json()) // expecting a json response
-    .then((json) => {
-      callback(json);
-    });
+  if (allMTOWithGeoJSON.length > 0) {
+    return GeoJSON.parse(allMTOWithGeoJSON, { GeoJSON: "geoJSON" });
+  }
+
+  return [];
 }
 
-//POLYLINE LAYERS
-function getMTOPolylineLayer(url, locations, callback) {
-  fetch(url)
-    .then((res) => res.json()) // expecting a json response
-    .then((json) => {
-      var allMTO = json;
-      var allMTOWithGeoJSON = [];
-      allMTO.forEach(function (element) {
-        // ONLY RETURN ROADS WITH SOME COVER
-        var mainCondition = element.Condition[0].toUpperCase();
-        var visibility = element.Visibility.toUpperCase();
+/**
+ * Fetch MTO point layer data (cameras, events, construction, etc.)
+ */
+async function getMTOPointLayer(url) {
+  const response = await fetch(url);
+  const isCameraLayer = url.toUpperCase().includes("CAMERA");
 
-        //if (mainCondition.indexOf('SNOW') != -1 || mainCondition.indexOf('ICE') != -1 || visibility.indexOf('POOR') != -1) {
-        if (mainCondition.indexOf("SNOW") != -1 || mainCondition.indexOf("ICE") != -1) {
-          // DECODE POLYLINE TO GEOJSON
-          var geoJSON = polyline.toGeoJSON(element.EncodedPolyline);
-          element.geoJSON = geoJSON;
+  if (isCameraLayer) {
+    // Handle camera data with Views array
+    const allCameras = await response.json();
+    const cameras = [];
 
-          // DELETE THE ENCODED POLYLINE
-          delete element.EncodedPolyline;
+    for (const camera of allCameras) {
+      const isIn = isInCounty(camera.Longitude, camera.Latitude);
+      if (isIn && camera.Views && camera.Views.length > 0) {
+        // Use the first enabled view
+        const primaryView = camera.Views.find((v) => v.Status === "Enabled") || camera.Views[0];
 
-          // SET TO ENGLISH ONLY
-          var englishDescription = "";
-          if (element.LocationDescription != undefined) {
-            englishDescription = element.LocationDescription.split("|")[0];
-            element.LocationDescription = englishDescription;
-
-            // ONLY USE THE ROADS FOUND IN CONFIG
-            if (locations.indexOf(englishDescription) != -1) {
-              // PUSH TO NEW ARRAY
-              allMTOWithGeoJSON.push(element);
-            }
-          } else {
-            // PUSH TO NEW ARRAY
-            allMTOWithGeoJSON.push(element);
-          }
-        }
-      });
-
-      if (allMTOWithGeoJSON.length > 0) {
-        // CONVERT THE ARRAY TO GEOJSON
-        var geo = GeoJSON.parse(allMTOWithGeoJSON, { GeoJSON: "geoJSON" });
-
-        // CALLBACK
-        callback(geo);
-      } else callback([]);
-    });
-}
-
-// POINT LAYERS
-function getMTOPointLayer(url, callback) {
-  fetch(url)
-    .then((res) => res.json()) // expecting a json response
-    .then((json) => {
-      var allMTO = json;
-      var mto = [];
-      allMTO.forEach(function (rec) {
-        var isIn = isInCounty(rec.Longitude, rec.Latitude);
-        if (isIn) {
-          // PLANNED EVENTS
-          if (rec.PlannedEndDate != undefined) {
-            // CONVERT UNIX TIME
-            var startDate = new Date(rec.StartDate * 1000); // The 0 there is the key, which sets the date to the epoch
-            var endDate = new Date(rec.PlannedEndDate * 1000); // The 0 there is the key, which sets the date to the epoch
-            var now = new Date();
-
-            if (now >= startDate && now <= endDate) {
-              rec.startDate = moment(startDate).format("YYYY-MM-DD HH:MM:SS A");
-              rec.endDate = moment(endDate).format("YYYY-MM-DD HH:MM:SS A");
-
-              mto.push(rec);
-            }
-          } else {
-            mto.push(rec);
-          }
-        }
-      });
-
-      //ADD CUSTOM CAMERAS
-      if (url.toUpperCase().indexOf("CAMERA") != -1) {
-        // GREY COUNTY
-        mto.push({ Description: "Roundabout at Gord Canning Drive and Grey County Road 19", Latitude: 44.4967, Longitude: -80.3018, Url: "https://www.grey.ca/cameras/roundabout.jpg" });
-        mto.push({ Description: "Grey County Road 124 and Grey Road 4", Latitude: 44.3409, Longitude: -80.249, Url: "https://www.grey.ca/cameras/124-4.jpg" });
-        mto.push({ Description: "Grey County Road 124 and Grey County Road 9", Latitude: 44.2675, Longitude: -80.2323, Url: "https://www.grey.ca/cameras/124-9.jpg" });
-
-        // YORK REGION
-        mto.push({ Description: "Highway 11 and Bathurst Street", Latitude: 44.105, Longitude: -79.5189, Url: "https://ww6.yorkmaps.ca/webtrafficimages/loc124.jpg" });
-        mto.push({ Description: "King Road and Duffering Street", Latitude: 44.0763, Longitude: -79.5387, Url: "https://ww6.yorkmaps.ca/webtrafficimages/loc153.jpg" });
-        mto.push({ Description: "Highway 27 and Highway 9", Latitude: 44.0111, Longitude: -79.6786, Url: "https://ww6.yorkmaps.ca/webtrafficimages/loc126.jpg" });
-
-        // DUFFERIN COUNTY
-        mto.push({ Description: "County Road 18 and 5th Sideroad", Latitude: 43.9725, Longitude: -79.992, Url: "http://cameras.dufferincounty.ca/airport-5.jpg" });
-        mto.push({ Description: "County Road 21 and County Road 24", Latitude: 44.2169, Longitude: -80.2199, Url: "http://cameras.dufferincounty.ca/124-21.jpg" });
-
-        // DURHAM
-        mto.push({
-          Description: "Highway 48 and Simcoe Street",
-          Latitude: 44.4252,
-          Longitude: -79.1226,
-          Url: "https://apps.durham.ca/Applications/Traffic/TrafficWatch/TrafficWatchData/10152339.jpg",
+        cameras.push({
+          Longitude: camera.Longitude,
+          Latitude: camera.Latitude,
+          Location: camera.Location,
+          Description: camera.Location,
+          Url: primaryView.Url,
         });
       }
+    }
 
-      // CONVERT THE ARRAY TO GEOJSON
-      var geo = GeoJSON.parse(mto, { Point: ["Latitude", "Longitude"] });
+    return GeoJSON.parse(cameras, { Point: ["Latitude", "Longitude"] });
+  } else {
+    // Handle other point layers (events, construction, etc.)
+    const allMTO = await response.json();
+    const mto = [];
+    const now = new Date();
 
-      // CALLBACK
-      callback(geo);
-    });
-}
+    for (const rec of allMTO) {
+      const isIn = isInCounty(rec.Longitude, rec.Latitude);
+      if (isIn) {
+        // Handle planned events with date range
+        if (rec.PlannedEndDate !== undefined && rec.StartDate !== undefined) {
+          const startDate = new Date(rec.StartDate * 1000);
+          const endDate = new Date(rec.PlannedEndDate * 1000);
 
-function getGreyCountyCameras() {
-  var cam1 = { Description: "Roundabout at Gord Canning Drive and Grey County Road 19", Latitude: 44.4967, Longitude: -80.3018, Url: "https://www.grey.ca/cameras/roundabout.jpg" };
-  var cam2 = { Description: "Grey County Road 124 and Grey Road 4", Latitude: 44.3409, Longitude: -80.249, Url: "https://www.grey.ca/cameras/124-4.jpg" };
-  var cam3 = { Description: "Grey County Road 124 and Grey County Road 9", Latitude: 44.2675, Longitude: -80.2323, Url: "https://www.grey.ca/cameras/124-9.jpg" };
-}
+          if (now >= startDate && now <= endDate) {
+            rec.startDate = formatDate(rec.StartDate);
+            rec.endDate = formatDate(rec.PlannedEndDate);
+            mto.push(rec);
+          }
+        } else {
+          mto.push(rec);
+        }
+      }
+    }
 
-function IsJsonString(str) {
-  try {
-    JSON.parse(str);
-  } catch (e) {
-    return false;
+    return GeoJSON.parse(mto, { Point: ["Latitude", "Longitude"] });
   }
-  return true;
 }
 
-function isInCounty(long, lat) {
-  if (long > -80.5 && long < -79 && lat > 43.9 && lat < 45) return true;
-  else return false;
+/**
+ * Main function to get MTO layer data by layer name
+ * @param {string} layerName - Layer name (EVENTS, CONSTRUCTION, CAMERAS, ROADCONDITIONS, etc.)
+ * @returns {Promise<Object|Array|null>} GeoJSON FeatureCollection or empty array
+ */
+async function getMTOLayer(layerName) {
+  const layerDetails = mtoSites.sites[layerName.toUpperCase()];
+
+  if (!layerDetails) {
+    return null;
+  }
+
+  switch (layerDetails.geoType) {
+    case "POINT":
+      return getMTOPointLayer(layerDetails.url);
+    case "POLYLINE":
+      return getMTOPolylineLayer(layerDetails.url);
+    case "NONE":
+      return getMTOAlerts(layerDetails.url);
+    default:
+      return null;
+  }
 }
+
+module.exports = {
+  getMTOLayer,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -529,27 +529,6 @@
         "glob": "^13.0.0"
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -885,9 +864,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1700,10 +1679,22 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.5.tgz",
-      "integrity": "sha512-JeaA2Vm9ffQKp9VjvfzObuMCjUYAp5WDYhRYL5LrBPY/jUDlUtOvDfot0vKSkB9tuX885BDHjtw4fZadD95wnA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
       "funding": [
         {
           "type": "github",
@@ -1712,6 +1703,7 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "fast-xml-builder": "^1.0.0",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -2763,18 +2755,39 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
-      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.3.tgz",
+      "integrity": "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -2863,6 +2876,16 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/mocha/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/mocha/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -2885,14 +2908,27 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mocha/node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2909,9 +2945,9 @@
       "license": "ISC"
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.8.tgz",
+      "integrity": "sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3135,9 +3171,9 @@
       }
     },
     "node_modules/nodemon/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4441,9 +4477,9 @@
       }
     },
     "node_modules/swagger-autogen/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -4462,9 +4498,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/routes/public/map/theme/511.js
+++ b/routes/public/map/theme/511.js
@@ -3,7 +3,7 @@ const common = require("../../../../helpers/common");
 const waze = require("../../../../helpers/waze");
 
 module.exports = (baseRoute, middleWare, router) => {
-  router.get(baseRoute + "/MTOLayer/:layerName", middleWare, (req, res, next) => {
+  router.get(baseRoute + "/MTOLayer/:layerName", middleWare, async (req, res, next) => {
     /* 
       #swagger.tags = ['Public/Map/Theme/511']
       #swagger.path = '/public/map/theme/511/MTOLayer/{layerName}'
@@ -19,10 +19,9 @@ module.exports = (baseRoute, middleWare, router) => {
     */
     try {
       if (!common.isHostAllowed(req, res)) return;
-      mto.getMTOLayer(req.params.layerName, function (response) {
-        res.send(response);
-        return next();
-      });
+      const response = await mto.getMTOLayer(req.params.layerName);
+      res.send(response);
+      return next();
     } catch (e) {
       console.error(e.stack);
       res.status(500);

--- a/routes/public/waze/index.js
+++ b/routes/public/waze/index.js
@@ -1,0 +1,40 @@
+const SqlServer = require("../../../helpers/sqlServer");
+
+module.exports = (baseRoute, middleWare, router) => {
+  router.get(baseRoute + "/roadclosures", middleWare, (req, res, next) => {
+    /* 
+      #swagger.tags = ['Public/Waze']
+      #swagger.path = '/public/waze/roadclosures'
+      #swagger.deprecated = false
+      #swagger.ignore = false
+      #swagger.summary = 'Get Waze Road Closures'
+    */
+    try {
+      const db = new SqlServer({ dbName: "tabular" });
+      const sql = `SELECT [id]
+                        ,[type]
+                        ,[subtype]
+                        ,[polyline]
+                        ,[street]
+                        ,[starttime]
+                        ,[endtime]
+                        ,[description]
+                        ,[direction]
+                   FROM [TABULAR].[dbo].[ssview_wazeroadclosures_wgs84]`;
+
+      db.selectAll(sql, (result) => {
+        if (result === undefined || result.error) {
+          res.send([]);
+        } else {
+          res.send(result);
+        }
+        return next();
+      });
+    } catch (e) {
+      console.error(e.stack);
+      res.status(500);
+      res.send();
+      return next();
+    }
+  });
+};


### PR DESCRIPTION
This pull request refactors and modernizes the MTO (Ministry of Transportation Ontario) 511 service helper, updates the related route handler to use async/await, and introduces a new endpoint for Waze road closures. The most significant changes are a full rewrite of the `helpers/mto.js` to use async/await, improved code clarity, and a new public API route for Waze data.

**MTO 511 Service Refactor and API Improvements:**

- Major refactor of `helpers/mto.js`:
  - Rewrites all callback-based functions to use async/await for cleaner, more maintainable asynchronous code.
  - Modularizes and documents helper functions for fetching and formatting MTO data (alerts, polylines, points).
  - Improves filtering logic, date formatting, and GeoJSON conversion for MTO layers.
  - Removes hardcoded camera additions, making the code more data-driven and easier to extend.

- Route handler update for MTO layers:
  - Changes the route `/MTOLayer/:layerName` to use the new async `getMTOLayer` function.
  - Adopts async/await in the Express route, simplifying error handling and response logic. [[1]](diffhunk://#diff-3d34a72c15c72c4a0835987a0752f14e3c872e3396383b78269f620626829efdL6-R6) [[2]](diffhunk://#diff-3d34a72c15c72c4a0835987a0752f14e3c872e3396383b78269f620626829efdL22-L25)

**New Waze Road Closures Endpoint:**

- Adds a new route `/public/waze/roadclosures`:
  - Connects to a SQL Server database and queries the `ssview_wazeroadclosures_wgs84` view.
  - Returns road closure data, handling errors gracefully.